### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ A modified MWC2.2 flight control for FlexBot hex board.
 
 And the project is one part of the [FlexBot Project](http://http://flexbot.cc/wiki/).
 
-##Source Code
+## Source Code
 You can either download the source using the "Download ZIP" button at the bottom left of the github page, or you can make a clone using git:
 
 ```
 git clone https://github.com/HexAirbot/HexNanoMWC_HEX.git
 ```
 
-####Latest release
+#### Latest release
 [version 1.0.3 source code](https://github.com/HexAirbot/HexNanoMWC_HEX/archive/v1.0.3.zip)
 
 
-####How to compile 
+#### How to compile 
 - Download the [Arduino IDE](http://arduino.cc/en/main/software#toc2) (you should use the version 1.0.5+).
 - Put all the source files (.ino files) from this repository in a folder called `HexNanoMWC_HEX`.
 - Open the main file ([HexNanoMWC_HEX.ino](HexNanoMWC_HEX.ino)) with the Arduino IDE, and the IDE will automatically open the other source files.
@@ -23,12 +23,12 @@ git clone https://github.com/HexAirbot/HexNanoMWC_HEX.git
   Select the correct COM Port
 - Click the verify and then the upload button
 
-##Development
+## Development
 The FlexBot Project is open source. 
 
 To contribute, you can send a pull request on Github, or share your idea to the [forum](http://makedesignshare.com).
 
-##Support
+## Support
 [Website](http://flexbot.cc)
 
 [Wiki](http://flexbot.cc/wiki)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
